### PR TITLE
Add support for ECR and fix build script copy wildcard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test:chrome": "cypress run --browser chrome --headed --no-exit --spec cypress/e2e/aws.cy.js",
     "test:firefox": "cypress run --browser firefox --headed --no-exit --spec cypress/e2e/aws.cy.js",
     "lint": "eslint .",
-    "build:chrome": "mkdir -p build/chrome/ && cp -r src/ assets/logo.png build/chrome/ && cp manifests/v3.json build/chrome/manifest.json && zip -j build/chrome.zip build/chrome/*",
-    "build:firefox": "mkdir -p build/firefox/ && cp -r src/ assets/logo.png build/firefox/ && cp manifests/v2.json build/firefox/manifest.json && zip -j build/firefox.zip build/firefox/*",
+    "build:chrome": "mkdir -p build/chrome/ && cp -r src/* assets/logo.png build/chrome/ && cp manifests/v3.json build/chrome/manifest.json && zip -j build/chrome.zip build/chrome/*",
+    "build:firefox": "mkdir -p build/firefox/ && cp -r src/* assets/logo.png build/firefox/ && cp manifests/v2.json build/firefox/manifest.json && zip -j build/firefox.zip build/firefox/*",
     "build": "npm run build:chrome && npm run build:firefox"
   },
   "repository": {

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -146,6 +146,10 @@ const queries = {
       querySelector: '#asg ~ div [role=dialog]:not([class*=awsui_hidden]) input[placeholder]',
     },
   ],
+  ECR: [
+    'div[data-testid="deleteRepositoryModal"] input[placeholder]', // delete repository
+    'div[data-testid="deleteImageModal"] input[placeholder]', // delete image
+  ],
   EFS: [
     // Replication
     {


### PR DESCRIPTION
This adds ECR autofill for deleting images and deleting repositories. I also needed to change the build copy script to use wildcards for the build to work correctly in my environment (WSL2 / Ubuntu / zsh), so I hope this makes it more universal.